### PR TITLE
Fix cicd

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -144,7 +144,7 @@ jobs:
 
            ./autogen.sh
            ./configure  
-           make -j`nproc`
+           make -j2
            sudo make install
            sudo mkdir /opt/digitalbits    
            sudo cp /usr/local/bin/digitalbits-core /opt/digitalbits/digitalbits-core     

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,4 +1,4 @@
-name: LinuxMacOS
+name: Build For All Platforms
 # Controls when the action will run. 
 on:
   push:
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 jobs:
   tagbump:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-16.04
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -43,6 +44,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Get Latest Tag
+        if: github.ref == 'refs/heads/master'
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1
 
@@ -82,18 +84,21 @@ jobs:
            sudo tar -czvf digitalbits-core-linux-amd64.tar.gz /opt/digitalbits/digitalbits-core
 
       - name: Make .deb package
+        if: github.ref == 'refs/heads/master'
         run: |
             fpm -f -s dir -t deb -n digitalbits-core -v ${{ steps.previoustag.outputs.tag }} --deb-use-file-permissions \
             /opt/digitalbits/digitalbits-core=/usr/local/bin/digitalbits-core \
             digitalbits-core.service=/etc/systemd/system/digitalbits-core.service \
             digitalbits-core=/etc/logrotate.d/digitalbits-core
       
-      - name: Make .rpm package 
+      - name: Make .rpm package
+        if: github.ref == 'refs/heads/master' 
         run: | 
           sudo alien -r -k digitalbits-core_${{ steps.previoustag.outputs.tag }}_amd64.deb
           sudo cp digitalbits-core-linux-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz 
           
       - name: Upload to cloudsmith.io
+        if: github.ref == 'refs/heads/master'
         run: |
           export CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
           export PATH=$PATH:$HOME/.local/bin
@@ -102,6 +107,7 @@ jobs:
           cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz 
 
       - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           allowUpdates: true
           artifacts: "digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz"
@@ -121,6 +127,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Get Latest Tag
+        if: github.ref == 'refs/heads/master'
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1
         
@@ -132,22 +139,25 @@ jobs:
 
       - name: Build the app    
         run: |
-          export CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
-          export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
-          sudo echo hello > digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64
-          sudo CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64
+           export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
 
            ./autogen.sh
            ./configure  
-           make -j2
+           make -j`nproc`
            sudo make install
            sudo mkdir /opt/digitalbits    
            sudo cp /usr/local/bin/digitalbits-core /opt/digitalbits/digitalbits-core     
            sudo tar -czvf digitalbits-core-darwin-amd64.tar.gz /opt/digitalbits/digitalbits-core
-           sudo cp digitalbits-core-darwin-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
-           cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
-
+         
+      - name: Push MasOS build to cloudsmith
+        if: github.ref == 'refs/heads/master'
+        run: |
+            export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
+            sudo cp digitalbits-core-darwin-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
+            sudo CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
+      
       - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           allowUpdates: true
           artifacts: "digitalbits-core-darwin-amd64.tar.gz"
@@ -203,12 +213,14 @@ jobs:
         run: |
             msbuild.exe Builds\VisualStudio\digitalbits-core.sln /p:platform="x64" /p:configuration="Release" /p:AdditionalLibPaths="C:\Program Files\PostgreSQL\9.5\include"
       - uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: digitalbits-core.exe
           path: Builds\VisualStudio\x64\Release\digitalbits-core.exe
 
   pushwindows:
     needs: windowsbuild
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -13,7 +13,6 @@ on:
   workflow_dispatch:
 jobs:
   tagbump:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-16.04
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -21,6 +20,7 @@ jobs:
         with:
           fetch-depth: '0'   # This workflow contains a single job called "build"
       - name: Github Tag Bump
+        if: github.ref == 'refs/heads/master'
         id: bump_version
         uses: anothrNick/github-tag-action@1.34.0
         env:
@@ -30,6 +30,7 @@ jobs:
           WITH_V: false
 
       - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           tag: ${{ steps.bump_version.outputs.tag }}
           bodyFile: "README.md"


### PR DESCRIPTION
On non-master branches:
- build binaries for all platforms
On master branch:
- build and release binaries, packages to cloudsmith