### PR TITLE
Fix cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,104 @@
+name: Build For All Platforms
+# Controls when the action will run. 
+on:
+  push:
+    branches-ignore:
+      - master
+  workflow_dispatch:
+jobs:
+  linuxbuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y git alien \
+                    build-essential pkg-config \
+                    autoconf automake libtool \
+                    bison flex libpq-dev \
+                    libunwind-dev parallel \
+                    clang-8 \
+                    gcc-6 g++-6 cpp-6 \
+                    libc++-8-dev libc++abi-8-dev unzip curl \
+                    python3-pip ruby ruby-dev rubygems python3-setuptools
+
+      - name: Build the app    
+        run: |
+          export CC=clang-8
+          export CXX=clang++-8
+          export CFLAGS="-O3 -g1 -fno-omit-frame-pointer"
+          export CXXFLAGS="$CFLAGS -stdlib=libc++" 
+           ./autogen.sh
+           ./configure  
+           make -j`nproc`
+
+  macosbuild:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Install deps
+        run: |
+          brew install automake
+          brew install libpqxx 
+          pip install --upgrade cloudsmith-cli
+
+      - name: Build the app    
+        run: |
+           export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
+
+           ./autogen.sh
+           ./configure  
+           make -j2
+
+  windowsbuild:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: recursive
+      - name: Install PostgresQL
+        run: |
+          curl -L -o postgresql.exe https://sbp.enterprisedb.com/getfile.jsp?fileid=1257550
+          .\postgresql.exe --unattendedmodeui minimal --mode unattended --superpassword "password" --servicename "postgreSQL" --servicepassword "password" --serverport 5432
+          setx /M path "%path%;C:\Program Files\PostgreSQL\9.5\bin"
+          
+      #cd lib\spdlog && mkdir build && cd build && cmake .. && make -j
+      - run: |          
+          curl -L -o postgresql.zip https://sbp.enterprisedb.com/getfile.jsp?fileid=1257551
+          Expand-Archive -Path postgresql.zip -DestinationPath .
+          mkdir -p "C:\Program Files\PostgreSQL\9.5\lib"
+          cp -r pgsql\lib\* "C:\Program Files\PostgreSQL\9.5\lib\"
+          dir "C:\Program Files\PostgreSQL\9.5\lib"
+          cp -r pgsql\include\* "C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\ucrt"
+          dir "C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\ucrt"
+      - name: Set up Cygwin
+        uses: egor-tensin/setup-cygwin@v3
+        with:
+          platform: x64
+          packages: flex bison sed curl gcc-core
+          
+      - name: setup-msbuild
+        uses: microsoft/setup-msbuild@v1 
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.5
+      
+      - run: |
+          nuget restore Builds\VisualStudio\digitalbits-core.sln
+          
+      - name: Create Build Directory
+        run: mkdir _build
+
+      - name: Build Solution
+        run: |
+            msbuild.exe Builds\VisualStudio\digitalbits-core.sln /p:platform="x64" /p:configuration="Release" /p:AdditionalLibPaths="C:\Program Files\PostgreSQL\9.5\include"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install git build-essential alien pkg-config \
           autoconf automake libtool bison flex libpq-dev libunwind-dev \
-          parallel gcc-8 g++-8 cpp-8 unzip curl
-
+          parallel gcc-8 g++-8 cpp-8 unzip curl \
+          python3-pip ruby ruby-dev rubygems python3-setuptools  \
+          pip3 install wheel
+          pip3 install cloudsmith-cli
+          cloudsmith --help
       - name: Build the app    
         run: |
            ./autogen.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install git build-essential alien pkg-config \
           autoconf automake libtool bison flex libpq-dev libunwind-dev \
-          parallel gcc-8 g++-8 cpp-8 unzip curl \
-          python3-pip ruby ruby-dev rubygems python3-setuptools 
-          pip3 install wheel
-          pip3 install cloudsmith-cli
-          cloudsmith --help
+          parallel gcc-8 g++-8 cpp-8 unzip curl
       - name: Build the app    
         run: |
            ./autogen.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,22 +19,12 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install -y git alien \
-                    build-essential pkg-config \
-                    autoconf automake libtool \
-                    bison flex libpq-dev \
-                    libunwind-dev parallel \
-                    clang-8 \
-                    gcc-6 g++-6 cpp-6 \
-                    libc++-8-dev libc++abi-8-dev unzip curl \
-                    python3-pip ruby ruby-dev rubygems python3-setuptools
+          sudo apt-get install git build-essential alien pkg-config \
+          autoconf automake libtool bison flex libpq-dev libunwind-dev \
+          parallel gcc-8 g++-8 cpp-8 unzip curl
 
       - name: Build the app    
         run: |
-          export CC=clang-8
-          export CXX=clang++-8
-          export CFLAGS="-O3 -g1 -fno-omit-frame-pointer"
-          export CXXFLAGS="$CFLAGS -stdlib=libc++" 
            ./autogen.sh
            ./configure  
            make -j`nproc`
@@ -49,7 +39,6 @@ jobs:
         run: |
           brew install automake
           brew install libpqxx 
-          pip install --upgrade cloudsmith-cli
 
       - name: Build the app    
         run: |
@@ -81,6 +70,7 @@ jobs:
           dir "C:\Program Files\PostgreSQL\9.5\lib"
           cp -r pgsql\include\* "C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\ucrt"
           dir "C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\ucrt"
+      
       - name: Set up Cygwin
         uses: egor-tensin/setup-cygwin@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get install git build-essential alien pkg-config \
           autoconf automake libtool bison flex libpq-dev libunwind-dev \
           parallel gcc-8 g++-8 cpp-8 unzip curl \
-          python3-pip ruby ruby-dev rubygems python3-setuptools  \
+          python3-pip ruby ruby-dev rubygems python3-setuptools 
           pip3 install wheel
           pip3 install cloudsmith-cli
           cloudsmith --help

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   tagbump:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}   
   linuxbuild:
     needs: tagbump
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -46,19 +46,12 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install -y git alien \
-                    build-essential pkg-config \
-                    autoconf automake libtool \
-                    bison flex libpq-dev \
-                    libunwind-dev parallel \
-                    clang-8 \
-                    gcc-6 g++-6 cpp-6 \
-                    libc++-8-dev libc++abi-8-dev unzip curl \
-                    python3-pip ruby ruby-dev rubygems python3-setuptools
+          sudo apt-get install git build-essential alien pkg-config \
+          autoconf automake libtool bison flex libpq-dev libunwind-dev \
+          parallel gcc-8 g++-8 cpp-8 unzip curl \
+          python3-pip ruby ruby-dev rubygems python3-setuptools 
           pip3 install wheel
-          pip3 install cloudsmith-cli==0.26.0
-          pip3 uninstall click -y
-          pip3 install click==7.1.2
+          pip3 install cloudsmith-cli
           sudo gem install --no-document fpm
 
       - name: Build the app    

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,15 +1,9 @@
-name: Build For All Platforms
+name: Release For All Platforms
 # Controls when the action will run. 
 on:
   push:
-  # Triggers the workflow on push or pull request events but only for the master branch
-#  push:
-#    branches: [ master ]
-#  pull_request:
-#    branches: [ master ]
-  # release:
-  #   types: [created]
-  # Allows you to run this workflow manually from the Actions tab
+    branches: 
+      - master
   workflow_dispatch:
 jobs:
   tagbump:
@@ -20,7 +14,6 @@ jobs:
         with:
           fetch-depth: '0'   # This workflow contains a single job called "build"
       - name: Github Tag Bump
-        if: github.ref == 'refs/heads/master'
         id: bump_version
         uses: anothrNick/github-tag-action@1.34.0
         env:
@@ -30,7 +23,6 @@ jobs:
           WITH_V: false
 
       - uses: ncipollo/release-action@v1
-        if: github.ref == 'refs/heads/master'
         with:
           tag: ${{ steps.bump_version.outputs.tag }}
           bodyFile: "README.md"
@@ -45,7 +37,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Get Latest Tag
-        if: github.ref == 'refs/heads/master'
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1
 
@@ -85,7 +76,6 @@ jobs:
            sudo tar -czvf digitalbits-core-linux-amd64.tar.gz /opt/digitalbits/digitalbits-core
 
       - name: Make .deb package
-        if: github.ref == 'refs/heads/master'
         run: |
             fpm -f -s dir -t deb -n digitalbits-core -v ${{ steps.previoustag.outputs.tag }} --deb-use-file-permissions \
             /opt/digitalbits/digitalbits-core=/usr/local/bin/digitalbits-core \
@@ -93,13 +83,11 @@ jobs:
             digitalbits-core=/etc/logrotate.d/digitalbits-core
       
       - name: Make .rpm package
-        if: github.ref == 'refs/heads/master' 
         run: | 
           sudo alien -r -k digitalbits-core_${{ steps.previoustag.outputs.tag }}_amd64.deb
           sudo cp digitalbits-core-linux-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz 
           
       - name: Upload to cloudsmith.io
-        if: github.ref == 'refs/heads/master'
         run: |
           export CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
           export PATH=$PATH:$HOME/.local/bin
@@ -108,7 +96,6 @@ jobs:
           cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz 
 
       - uses: ncipollo/release-action@v1
-        if: github.ref == 'refs/heads/master'
         with:
           allowUpdates: true
           artifacts: "digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz"
@@ -128,7 +115,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Get Latest Tag
-        if: github.ref == 'refs/heads/master'
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1
         
@@ -151,14 +137,12 @@ jobs:
            sudo tar -czvf digitalbits-core-darwin-amd64.tar.gz /opt/digitalbits/digitalbits-core
          
       - name: Push MasOS build to cloudsmith
-        if: github.ref == 'refs/heads/master'
         run: |
             export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
             sudo cp digitalbits-core-darwin-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
             sudo CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
       
       - uses: ncipollo/release-action@v1
-        if: github.ref == 'refs/heads/master'
         with:
           allowUpdates: true
           artifacts: "digitalbits-core-darwin-amd64.tar.gz"
@@ -214,14 +198,12 @@ jobs:
         run: |
             msbuild.exe Builds\VisualStudio\digitalbits-core.sln /p:platform="x64" /p:configuration="Release" /p:AdditionalLibPaths="C:\Program Files\PostgreSQL\9.5\include"
       - uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master'
         with:
           name: digitalbits-core.exe
           path: Builds\VisualStudio\x64\Release\digitalbits-core.exe
 
   pushwindows:
     needs: windowsbuild
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -144,7 +144,7 @@ jobs:
 
            ./autogen.sh
            ./configure  
-           make -j`nproc`
+           make -j2
            sudo make install
            sudo mkdir /opt/digitalbits    
            sudo cp /usr/local/bin/digitalbits-core /opt/digitalbits/digitalbits-core     

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -56,10 +56,6 @@ jobs:
 
       - name: Build the app    
         run: |
-          export ENV CC=clang-8
-          export ENV CXX=clang++-8
-          export ENV CFLAGS="-O3 -g1 -fno-omit-frame-pointer"
-          export ENV CXXFLAGS="$CFLAGS -stdlib=libc++" 
            ./autogen.sh
            ./configure  
            make -j`nproc`

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,4 +1,4 @@
-name: LinuxMacOS
+name: Build For All Platforms
 # Controls when the action will run. 
 on:
   push:
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 jobs:
   tagbump:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-16.04
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -43,6 +44,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Get Latest Tag
+        if: github.ref == 'refs/heads/master'
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1
 
@@ -82,18 +84,21 @@ jobs:
            sudo tar -czvf digitalbits-core-linux-amd64.tar.gz /opt/digitalbits/digitalbits-core
 
       - name: Make .deb package
+        if: github.ref == 'refs/heads/master'
         run: |
             fpm -f -s dir -t deb -n digitalbits-core -v ${{ steps.previoustag.outputs.tag }} --deb-use-file-permissions \
             /opt/digitalbits/digitalbits-core=/usr/local/bin/digitalbits-core \
             digitalbits-core.service=/etc/systemd/system/digitalbits-core.service \
             digitalbits-core=/etc/logrotate.d/digitalbits-core
       
-      - name: Make .rpm package 
+      - name: Make .rpm package
+        if: github.ref == 'refs/heads/master' 
         run: | 
           sudo alien -r -k digitalbits-core_${{ steps.previoustag.outputs.tag }}_amd64.deb
           sudo cp digitalbits-core-linux-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz 
           
       - name: Upload to cloudsmith.io
+        if: github.ref == 'refs/heads/master'
         run: |
           export CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
           export PATH=$PATH:$HOME/.local/bin
@@ -102,6 +107,7 @@ jobs:
           cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz 
 
       - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           allowUpdates: true
           artifacts: "digitalbits-core_${{ steps.previoustag.outputs.tag }}_linux-amd64.tar.gz"
@@ -121,6 +127,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Get Latest Tag
+        if: github.ref == 'refs/heads/master'
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1
         
@@ -132,22 +139,25 @@ jobs:
 
       - name: Build the app    
         run: |
-          export CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
-          export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
-          sudo echo hello > digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64
-          sudo CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64
+           export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
 
            ./autogen.sh
            ./configure  
-           make -j2
+           make -j`nproc`
            sudo make install
            sudo mkdir /opt/digitalbits    
            sudo cp /usr/local/bin/digitalbits-core /opt/digitalbits/digitalbits-core     
            sudo tar -czvf digitalbits-core-darwin-amd64.tar.gz /opt/digitalbits/digitalbits-core
-           sudo cp digitalbits-core-darwin-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
-           cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
-
+         
+      - name: Push MasOS build to cloudsmith
+        if: github.ref == 'refs/heads/master'
+        run: |
+            export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/2.7/bin
+            sudo cp digitalbits-core-darwin-amd64.tar.gz digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
+            sudo CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} cloudsmith push raw xdb-foundation/digitalbits-core digitalbits-core_${{ steps.previoustag.outputs.tag }}_darwin-amd64.tar.gz 
+      
       - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           allowUpdates: true
           artifacts: "digitalbits-core-darwin-amd64.tar.gz"
@@ -203,12 +213,14 @@ jobs:
         run: |
             msbuild.exe Builds\VisualStudio\digitalbits-core.sln /p:platform="x64" /p:configuration="Release" /p:AdditionalLibPaths="C:\Program Files\PostgreSQL\9.5\include"
       - uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: digitalbits-core.exe
           path: Builds\VisualStudio\x64\Release\digitalbits-core.exe
 
   pushwindows:
     needs: windowsbuild
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -13,7 +13,6 @@ on:
   workflow_dispatch:
 jobs:
   tagbump:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-16.04
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -21,6 +20,7 @@ jobs:
         with:
           fetch-depth: '0'   # This workflow contains a single job called "build"
       - name: Github Tag Bump
+        if: github.ref == 'refs/heads/master'
         id: bump_version
         uses: anothrNick/github-tag-action@1.34.0
         env:
@@ -30,6 +30,7 @@ jobs:
           WITH_V: false
 
       - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           tag: ${{ steps.bump_version.outputs.tag }}
           bodyFile: "README.md"


### PR DESCRIPTION
On non-master branches:
- build binaries for all platforms

On master branch:
- build and release binaries for all platforms, upload to cloudsmith

Workflow updated to be run on ubuntu-latest due to fact that ubuntu-16.04 support will be dropped by GitHub on September 20, 2021 https://github.com/actions/virtual-environments/issues/3287